### PR TITLE
Add demo video and demo related scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ graph TD
 
 For details, please reach out to <sales@zubax.com>.
 
+## Demo
+
+<a href="https://youtu.be/YgZulY8uraQ"><img src="https://img.youtube.com/vi/YgZulY8uraQ/maxresdefault.jpg" width="560" alt="Replaying DroneCAN traffic from GNSS with Nestor"></a>
+
+▶️ **[Replaying DroneCAN traffic from GNSS with Nestor](https://youtu.be/YgZulY8uraQ)**
+
 ## Usage
 
 Install and run the server at the default endpoint <http://0.0.0.0:8000>

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,69 +2,23 @@
 
 This folder contains standalone self-contained helper scripts for data ingestion, fetching, and server validation.
 
-## `nestor_ingest.py`
+Each script documents its own invocation examples in its module docstring (run with `--help` or read the top of the file).
 
-Uploads one or more raw `.cf3d` files to the server.
-The script reads file bytes, sends them in chunks, retries on transient failures, and prints a final report.
+| Tool | What it does |
+| --- | --- |
+| `nestor_ingest.py` | Uploads one or more raw `.cf3d` files to the server. Reads file bytes, sends them in chunks, retries on transient failures, and prints a final report. |
+| `export_cf3d.py` | Dumps CAN frames from a Nestor SQLite database to a `.cf3d` file. Output uses the same record format as live ingest, so it can be replayed with `nestor_ingest.py`. Pass `--boot-id N` to restrict to a single boot session. |
+| `replay_cf3d.py` | Replays CAN frames from a `.cf3d` file onto a (virtual) CAN interface via `python-can`. Inter-frame timing is reconstructed from each record's `hw_ts_us`. CAN FD is enabled by default to allow payloads larger than 8 bytes. |
+| `capture_cf3d.py` | Records live CAN frames from an interface into a `.cf3d` file. Passive listener -- run an allocator (e.g. the DroneCAN GUI Tool) alongside it for plug-and-play nodes. |
+| `nestor_replay.py` | Inverse of `nestor_ingest`: pulls a device's frames from the server and replays them onto a (virtual) CAN interface. `--follow` for a live tail. |
+| `e2e_test.py` | Runs a full local E2E check; intended for development only. Read the contents for details. |
+| `serve_smoke_test.py` | Focused startup smoke test for `nestor serve` (used by the `nox -s serve_smoke` session): launches a real `nestor serve` process in a temporary environment, waits for readiness via `GET /cf3d/api/v1/devices`, then terminates it and reports diagnostics on failure. |
 
-```bash
-python tools/nestor_ingest.py --server http://127.0.0.1:8000 --device_uid 0x123 --device "Vehicle-A" data/*.cf3d
-```
+## Interface setup
 
-## `export_cf3d.py`
+Some tools need a (virtual) CAN interface up first:
 
-Dumps CAN frames stored in a Nestor SQLite database to a `.cf3d` file. The
-output uses the same record format as live ingest, so it can be replayed with
-`nestor_ingest.py`.
-
-```bash
-python tools/export_cf3d.py --db nestor.db --device "my device" --out dump.cf3d
-```
-
-Pass `--boot-id N` to restrict the export to a single boot session.
-
-## `replay_cf3d.py`
-
-Replays the CAN frames stored in a `.cf3d` file onto a (virtual) CAN interface
-via `python-can`. Inter-frame timing is reconstructed from each record's
-`hw_ts_us`, so the bus sees traffic at roughly its original rate. CAN FD is
-enabled by default to allow payloads larger than 8 bytes.
-
-```bash
-python tools/replay_cf3d.py --iface vcan0 dump.cf3d
-python tools/replay_cf3d.py --iface vcan0 --speed 2.0 dump.cf3d
-python tools/replay_cf3d.py --iface vcan0 --no-timing dump.cf3d
-```
-
-Set up `vcan0` first with `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`.
-
-## `capture_cf3d.py`
-
-Record live CAN frames from an interface into a `.cf3d` file. Passive listener -- run an allocator (e.g. the DroneCAN GUI Tool) alongside it for plug-and-play nodes.
-
-```bash
-python tools/capture_cf3d.py --channel can0 --out gnss.cf3d
-```
-
-Bring up `can0` from a Babel first: `sudo slcand -o -c -s8 /dev/ttyACM0 can0 && sudo ip link set up can0`.
-
-## `nestor_replay.py`
-
-Inverse of `nestor_ingest`: pull a device's frames from the server and replay them onto a (virtual) CAN interface. `--follow` for a live tail.
-
-```bash
-python tools/nestor_replay.py --server https://cyphalcloud.zubax.com --device "my device" --boot-id 1 --iface vcan0
-```
-
-## `e2e_test.py`
-
-Runs a full local E2E check; intended for development only. Read the contents for details.
-
-## `serve_smoke_test.py`
-
-Runs a focused startup smoke test for `nestor serve`:
-- launches a real `nestor serve` process in a temporary environment,
-- waits for readiness via `GET /cf3d/api/v1/devices`,
-- terminates the process and reports detailed diagnostics on failure.
-
-This is the script used by the `nox -s serve_smoke` session.
+- **`vcan0`** (for `replay_cf3d.py` / `nestor_replay.py`):
+  `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`
+- **`can0`** from a Zubax Babel (for `capture_cf3d.py`):
+  `sudo slcand -o -c -s8 /dev/ttyACM0 can0 && sudo ip link set up can0`

--- a/tools/README.md
+++ b/tools/README.md
@@ -6,13 +6,13 @@ Each script documents its own invocation examples in its module docstring (run w
 
 | Tool | What it does |
 | --- | --- |
-| `nestor_ingest.py` | Uploads one or more raw `.cf3d` files to the server. Reads file bytes, sends them in chunks, retries on transient failures, and prints a final report. |
-| `export_cf3d.py` | Dumps CAN frames from a Nestor SQLite database to a `.cf3d` file. Output uses the same record format as live ingest, so it can be replayed with `nestor_ingest.py`. Pass `--boot-id N` to restrict to a single boot session. |
-| `replay_cf3d.py` | Replays CAN frames from a `.cf3d` file onto a (virtual) CAN interface via `python-can`. Inter-frame timing is reconstructed from each record's `hw_ts_us`. CAN FD is enabled by default to allow payloads larger than 8 bytes. |
-| `capture_cf3d.py` | Records live CAN frames from an interface into a `.cf3d` file. Passive listener -- run an allocator (e.g. the DroneCAN GUI Tool) alongside it for plug-and-play nodes. |
-| `nestor_replay.py` | Inverse of `nestor_ingest`: pulls a device's frames from the server and replays them onto a (virtual) CAN interface. `--follow` for a live tail. |
-| `e2e_test.py` | Runs a full local E2E check; intended for development only. Read the contents for details. |
-| `serve_smoke_test.py` | Focused startup smoke test for `nestor serve` (used by the `nox -s serve_smoke` session): launches a real `nestor serve` process in a temporary environment, waits for readiness via `GET /cf3d/api/v1/devices`, then terminates it and reports diagnostics on failure. |
+| `nestor_ingest.py` | Uploads one or more raw `.cf3d` files to the server. |
+| `export_cf3d.py` | Dumps CAN frames from a Nestor SQLite database to a `.cf3d` file. |
+| `replay_cf3d.py` | Replays CAN frames from a `.cf3d` file onto a (virtual) CAN interface via `python-can`. Inter-frame timing is reconstructed from each record's `hw_ts_us`. |
+| `capture_cf3d.py` | Records live CAN frames from an interface into a `.cf3d` file. |
+| `nestor_replay.py` | Inverse of `nestor_ingest`: pulls a device's frames from the server and replays them onto a (virtual) CAN interface. |
+| `e2e_test.py` | Runs a full local E2E check; intended for development only. |
+| `serve_smoke_test.py` | Focused startup smoke test for `nestor serve` (invoked from Nox): launches a real `nestor serve` process in a temporary environment, waits for readiness via `GET /cf3d/api/v1/devices`, then terminates it and reports diagnostics on failure. |
 
 ## Interface setup
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,6 +11,51 @@ The script reads file bytes, sends them in chunks, retries on transient failures
 python tools/nestor_ingest.py --server http://127.0.0.1:8000 --device_uid 0x123 --device "Vehicle-A" data/*.cf3d
 ```
 
+## `export_cf3d.py`
+
+Dumps CAN frames stored in a Nestor SQLite database to a `.cf3d` file. The
+output uses the same record format as live ingest, so it can be replayed with
+`nestor_ingest.py`.
+
+```bash
+python tools/export_cf3d.py --db nestor.db --device "my device" --out dump.cf3d
+```
+
+Pass `--boot-id N` to restrict the export to a single boot session.
+
+## `replay_cf3d.py`
+
+Replays the CAN frames stored in a `.cf3d` file onto a (virtual) CAN interface
+via `python-can`. Inter-frame timing is reconstructed from each record's
+`hw_ts_us`, so the bus sees traffic at roughly its original rate. CAN FD is
+enabled by default to allow payloads larger than 8 bytes.
+
+```bash
+python tools/replay_cf3d.py --iface vcan0 dump.cf3d
+python tools/replay_cf3d.py --iface vcan0 --speed 2.0 dump.cf3d
+python tools/replay_cf3d.py --iface vcan0 --no-timing dump.cf3d
+```
+
+Set up `vcan0` first with `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`.
+
+## `capture_cf3d.py`
+
+Record live CAN frames from an interface into a `.cf3d` file. Passive listener -- run an allocator (e.g. the DroneCAN GUI Tool) alongside it for plug-and-play nodes.
+
+```bash
+python tools/capture_cf3d.py --channel can0 --out gnss.cf3d
+```
+
+Bring up `can0` from a Babel first: `sudo slcand -o -c -s8 /dev/ttyACM0 can0 && sudo ip link set up can0`.
+
+## `nestor_replay.py`
+
+Inverse of `nestor_ingest`: pull a device's frames from the server and replay them onto a (virtual) CAN interface. `--follow` for a live tail.
+
+```bash
+python tools/nestor_replay.py --server https://cyphalcloud.zubax.com --device "my device" --boot-id 1 --iface vcan0
+```
+
 ## `e2e_test.py`
 
 Runs a full local E2E check; intended for development only. Read the contents for details.

--- a/tools/capture_cf3d.py
+++ b/tools/capture_cf3d.py
@@ -1,18 +1,6 @@
 #!/usr/bin/env python3
 """
 capture_cf3d: Record live CAN frames from a (v)CAN interface into a .cf3d file.
-
-This is a passive listener: it reads frames from a python-can interface (e.g. a
-socketcan `can0` backed by a Zubax Babel via slcand) and writes each one into a
-.cf3d file using the exact record layout produced by tools/export_cf3d.py, so
-the capture can be replayed unchanged with tools/replay_cf3d.py.
-
-It does NOT allocate node IDs. On a bus with plug-and-play nodes (e.g. a GNSS),
-run an allocation server alongside it -- the DroneCAN GUI Tool's dynamic node ID
-allocation server is the easy choice -- so the nodes obtain IDs and start
-publishing while this tool records. socketcan lets the GUI and this recorder
-read the same interface simultaneously.
-
 Usage:
     python tools/capture_cf3d.py --channel can0 --out gnss.cf3d
     python tools/capture_cf3d.py --channel can0 --duration 60 --out gnss.cf3d

--- a/tools/capture_cf3d.py
+++ b/tools/capture_cf3d.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""
+capture_cf3d: Record live CAN frames from a (v)CAN interface into a .cf3d file.
+
+This is a passive listener: it reads frames from a python-can interface (e.g. a
+socketcan `can0` backed by a Zubax Babel via slcand) and writes each one into a
+.cf3d file using the exact record layout produced by tools/export_cf3d.py, so
+the capture can be replayed unchanged with tools/replay_cf3d.py.
+
+It does NOT allocate node IDs. On a bus with plug-and-play nodes (e.g. a GNSS),
+run an allocation server alongside it -- the DroneCAN GUI Tool's dynamic node ID
+allocation server is the easy choice -- so the nodes obtain IDs and start
+publishing while this tool records. socketcan lets the GUI and this recorder
+read the same interface simultaneously.
+
+Usage:
+    python tools/capture_cf3d.py --channel can0 --out gnss.cf3d
+    python tools/capture_cf3d.py --channel can0 --duration 60 --out gnss.cf3d
+    python tools/capture_cf3d.py --channel vcan0 --interface socketcan --out dump.cf3d
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import struct
+import sys
+import time
+from pathlib import Path
+
+import can
+
+from nestor.fec_envelope import box, USER_DATA_BYTES, RECORD_BYTES
+from nestor.model import CAN_EFF_FLAG, CAN_RTR_FLAG, CAN_ERR_FLAG, CAN_ID_EXT_MASK
+
+LOGGER = logging.getLogger("capture_cf3d")
+
+
+def pack_cf3d_record(boot_id: int, seqno: int, hw_ts_us: int, can_id_with_flags: int, data: bytes) -> bytes:
+    # Layout copied verbatim from tools/export_cf3d.py so captured records are
+    # byte-identical to exported ones and replay is guaranteed.
+    if len(data) > 64:
+        raise ValueError(f"CAN payload too long: {len(data)} > 64")
+    buf = bytearray(USER_DATA_BYTES)
+    buf[0] = 0  # version
+    struct.pack_into("<QQQ", buf, 8, boot_id, seqno, hw_ts_us)
+    struct.pack_into("<I", buf, 36, can_id_with_flags)
+    buf[40] = len(data)
+    buf[41 : 41 + len(data)] = data
+    return box(bytes(buf))
+
+
+def message_to_can_id_with_flags(msg: can.Message) -> int:
+    # Inverse of tools/replay_cf3d.py:to_can_message, so capture -> replay is a
+    # faithful round-trip of the arbitration ID and the EFF/RTR/ERR flags.
+    value = msg.arbitration_id & CAN_ID_EXT_MASK
+    if msg.is_extended_id:
+        value |= CAN_EFF_FLAG
+    if msg.is_remote_frame:
+        value |= CAN_RTR_FLAG
+    if msg.is_error_frame:
+        value |= CAN_ERR_FLAG
+    return value
+
+
+def capture(channel: str, bustype: str, out_path: Path, boot_id: int, duration: float | None) -> int:
+    LOGGER.info("Opening CAN bus interface=%s channel=%s", bustype, channel)
+    bus = can.Bus(interface=bustype, channel=channel)
+    written = 0
+    seqno = 0
+    deadline = None if duration is None else time.monotonic() + duration
+    LOGGER.info("Recording to %s (boot_id=%d); press Ctrl+C to stop", out_path, boot_id)
+    try:
+        with out_path.open("wb") as fh:
+            while True:
+                if deadline is not None and time.monotonic() >= deadline:
+                    LOGGER.info("Reached requested duration of %.1fs, stopping", duration)
+                    break
+                msg = bus.recv(timeout=1.0)
+                if msg is None:
+                    continue
+
+                data = bytes(msg.data)
+                if len(data) > 64:
+                    LOGGER.warning("Skipping oversized frame: %d bytes", len(data))
+                    continue
+                hw_ts_us = int(msg.timestamp * 1e6)
+                can_id_with_flags = message_to_can_id_with_flags(msg)
+
+                try:
+                    record = pack_cf3d_record(boot_id, seqno, hw_ts_us, can_id_with_flags, data)
+                except Exception as exc:
+                    LOGGER.critical("Failed to pack frame seqno=%d: %s", seqno, exc, exc_info=True)
+                    continue
+                if len(record) != RECORD_BYTES:
+                    LOGGER.critical("pack_cf3d_record produced %d bytes, expected %d", len(record), RECORD_BYTES)
+                    continue
+
+                fh.write(record)
+                LOGGER.debug(
+                    "recorded seqno=%d can_id=0x%08x dlc=%d hw_ts_us=%d",
+                    seqno,
+                    can_id_with_flags,
+                    len(data),
+                    hw_ts_us,
+                )
+                seqno += 1
+                written += 1
+                if written % 1000 == 0:
+                    LOGGER.debug("Recorded %d frames so far", written)
+    except KeyboardInterrupt:
+        LOGGER.info("Interrupted by user, stopping")
+    finally:
+        LOGGER.info("Shutting down CAN bus")
+        bus.shutdown()
+
+    LOGGER.info("Capture finished: recorded %d frames (%d bytes) to %s", written, written * RECORD_BYTES, out_path)
+    return written
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", type=Path, required=True, help="Output .cf3d file path")
+    parser.add_argument("--channel", default="can0", help="CAN interface channel (default: can0)")
+    parser.add_argument("--interface", default="socketcan", help="python-can interface name (default: socketcan)")
+    parser.add_argument(
+        "--boot-id",
+        type=int,
+        default=None,
+        help="Boot ID stamped into every record (default: current Unix time)",
+    )
+    parser.add_argument("--duration", type=float, default=None, help="Stop automatically after N seconds")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG/INFO/WARNING/ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.duration is not None and args.duration <= 0:
+        LOGGER.error("--duration must be positive, got %r", args.duration)
+        return 1
+
+    boot_id = args.boot_id if args.boot_id is not None else int(time.time())
+
+    try:
+        written = capture(
+            channel=args.channel,
+            bustype=args.interface,
+            out_path=args.out,
+            boot_id=boot_id,
+            duration=args.duration,
+        )
+    except Exception as exc:
+        LOGGER.critical("Capture failed: %s", exc, exc_info=True)
+        return 1
+
+    if written == 0:
+        LOGGER.warning("No frames recorded")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/export_cf3d.py
+++ b/tools/export_cf3d.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
 """
 export_cf3d: Dump CAN frames stored in a Nestor SQLite database to a .cf3d file.
-
-The resulting file is byte-identical in format to the .cf3d records the server
-ingests via /cf3d/api/v1/commit, so it can be replayed with nestor_ingest.
-
 Usage:
     python tools/export_cf3d.py --db nestor.db --device "my device" --out dump.cf3d
     python tools/export_cf3d.py --db nestor.db --device "my device" --boot-id 0 --out dump.cf3d

--- a/tools/export_cf3d.py
+++ b/tools/export_cf3d.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+export_cf3d: Dump CAN frames stored in a Nestor SQLite database to a .cf3d file.
+
+The resulting file is byte-identical in format to the .cf3d records the server
+ingests via /cf3d/api/v1/commit, so it can be replayed with nestor_ingest.
+
+Usage:
+    python tools/export_cf3d.py --db nestor.db --device "my device" --out dump.cf3d
+    python tools/export_cf3d.py --db nestor.db --device "my device" --boot-id 0 --out dump.cf3d
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sqlite3
+import struct
+import sys
+from pathlib import Path
+
+from nestor.fec_envelope import box, USER_DATA_BYTES, RECORD_BYTES
+
+LOGGER = logging.getLogger("export_cf3d")
+
+
+def pack_cf3d_record(boot_id: int, seqno: int, hw_ts_us: int, can_id_with_flags: int, data: bytes) -> bytes:
+    if len(data) > 64:
+        raise ValueError(f"CAN payload too long: {len(data)} > 64")
+    buf = bytearray(USER_DATA_BYTES)
+    buf[0] = 0  # version
+    struct.pack_into("<QQQ", buf, 8, boot_id, seqno, hw_ts_us)
+    struct.pack_into("<I", buf, 36, can_id_with_flags)
+    buf[40] = len(data)
+    buf[41 : 41 + len(data)] = data
+    return box(bytes(buf))
+
+
+def export(db_path: Path, device: str, boot_id: int | None, out_path: Path) -> int:
+    LOGGER.info("Opening database read-only: %s", db_path)
+    uri = f"file:{db_path}?mode=ro"
+    connection = sqlite3.connect(uri, uri=True)
+    try:
+        cursor = connection.cursor()
+
+        cursor.execute("SELECT device_id FROM devices WHERE device=?", (device,))
+        row = cursor.fetchone()
+        if row is None:
+            LOGGER.error("Unknown device %r in %s", device, db_path)
+            return 0
+        device_id = int(row[0])
+        LOGGER.debug("Resolved device=%r to device_id=%d", device, device_id)
+
+        if boot_id is None:
+            cursor.execute(
+                "SELECT boot_id, seqno, hw_ts_us, can_id_with_flags, data "
+                "FROM can_frames WHERE device_id=? ORDER BY seqno ASC",
+                (device_id,),
+            )
+        else:
+            cursor.execute(
+                "SELECT boot_id, seqno, hw_ts_us, can_id_with_flags, data "
+                "FROM can_frames WHERE device_id=? AND boot_id=? ORDER BY seqno ASC",
+                (device_id, int(boot_id)),
+            )
+
+        written = 0
+        with out_path.open("wb") as fh:
+            for boot, seqno, hw_ts_us, can_id_with_flags, data in cursor:
+                record = pack_cf3d_record(int(boot), int(seqno), int(hw_ts_us), int(can_id_with_flags), bytes(data))
+                if len(record) != RECORD_BYTES:
+                    LOGGER.critical("pack_cf3d_record produced %d bytes, expected %d", len(record), RECORD_BYTES)
+                    raise RuntimeError("internal error: bad record length")
+                fh.write(record)
+                written += 1
+                if written % 1000 == 0:
+                    LOGGER.debug("Written %d records so far", written)
+
+        LOGGER.info(
+            "Exported %d records (%d bytes) for device=%r boot_id=%s to %s",
+            written,
+            written * RECORD_BYTES,
+            device,
+            boot_id if boot_id is not None else "ALL",
+            out_path,
+        )
+        return written
+    finally:
+        connection.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--db", type=Path, required=True, help="Path to nestor.db")
+    parser.add_argument("--device", required=True, help="Device name as stored in the database")
+    parser.add_argument("--boot-id", type=int, default=None, help="Restrict export to a single boot_id")
+    parser.add_argument("--out", type=Path, required=True, help="Output .cf3d file path")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG/INFO/WARNING/ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not args.db.exists():
+        LOGGER.error("Database file not found: %s", args.db)
+        return 1
+
+    written = export(args.db, args.device, args.boot_id, args.out)
+    if written == 0:
+        LOGGER.warning("No records exported")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/nestor_ingest.py
+++ b/tools/nestor_ingest.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Sequence
 
 COMMIT_PATH = "/cf3d/api/v1/commit"
-CHUNK_BYTES = 8 * 1024 * 1024
+CHUNK_BYTES = 256 * 1024  # multiple of the 256-byte record size; small enough to clear typical proxy limits (HTTP 413)
 REQUEST_TIMEOUT_S = 30.0
 MAX_ATTEMPTS = 5
 BASE_BACKOFF_S = 1.0

--- a/tools/nestor_ingest.py
+++ b/tools/nestor_ingest.py
@@ -14,6 +14,9 @@ Behavior summary:
 Notes:
   - This tool sends opaque bytes; it does not parse CF3D payload contents.
   - The server may still reject malformed data at decode/parse time.
+
+Usage:
+    python tools/nestor_ingest.py --server http://127.0.0.1:8000 --device_uid 0x123 --device "Vehicle-A" data/*.cf3d
 """
 
 from __future__ import annotations

--- a/tools/nestor_replay.py
+++ b/tools/nestor_replay.py
@@ -4,7 +4,7 @@ nestor_replay: Replay CAN frames stored on a Nestor server onto a (v)CAN interfa
 
 The inverse of nestor_ingest: instead of pushing .cf3d records to the server, this
 pulls a device's recorded frames back out via the REST query API
-(GET /cf3d/api/v1/records) and transmits them with python-can, so any DroneCAN tool
+(GET /cf3d/api/v1/records) and transmits them with python-can, so any CAN tool
 (e.g. the DroneCAN GUI Tool) can decode/plot an archived session as if it were live.
 
 Records are paged by seqno (server caps each page; default/max page size 10000) and

--- a/tools/nestor_replay.py
+++ b/tools/nestor_replay.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""
+nestor_replay: Replay CAN frames stored on a Nestor server onto a (v)CAN interface.
+
+The inverse of nestor_ingest: instead of pushing .cf3d records to the server, this
+pulls a device's recorded frames back out via the REST query API
+(GET /cf3d/api/v1/records) and transmits them with python-can, so any DroneCAN tool
+(e.g. the DroneCAN GUI Tool) can decode/plot an archived session as if it were live.
+
+Records are paged by seqno (server caps each page; default/max page size 10000) and
+replayed with inter-frame delays derived from hw_ts_us, preserving original timing.
+With --follow it long-polls for new records and keeps streaming (live tail).
+
+Usage:
+    python tools/nestor_replay.py --server https://cyphalcloud.zubax.com \
+        --device "gnss-bench-test" --boot-id 1781871628 --iface vcan0
+    python tools/nestor_replay.py --server http://localhost:8000 \
+        --device my-drone --boot-id 1 --iface vcan0 --speed 2.0
+    python tools/nestor_replay.py --server http://localhost:8000 \
+        --device my-drone --boot-id 1 --iface vcan0 --follow
+
+Set up vcan0 first with `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import can
+
+LOGGER = logging.getLogger("nestor_replay")
+
+RECORDS_PATH = "/cf3d/api/v1/records"
+MAX_PAGE_LIMIT = 10000
+REQUEST_TIMEOUT_S = 60.0
+# Server-side long-poll cap (see rest_api.WAIT_MAX_TIMEOUT_S).
+FOLLOW_WAIT_TIMEOUT_S = 30
+
+
+def fetch_page(
+    server: str,
+    device: str,
+    boot_ids: list[int],
+    seqno_min: int | None,
+    limit: int,
+    wait_timeout_s: int,
+) -> dict:
+    base = server.rstrip("/") + RECORDS_PATH
+    query: list[tuple[str, str]] = [("device", device)]
+    for boot_id in boot_ids:
+        query.append(("boot_id", str(boot_id)))
+    if seqno_min is not None:
+        query.append(("seqno_min", str(seqno_min)))
+    query.append(("limit", str(limit)))
+    if wait_timeout_s > 0:
+        query.append(("wait_timeout_s", str(wait_timeout_s)))
+    url = base + "?" + urllib.parse.urlencode(query)
+    LOGGER.debug("GET %s", url)
+    request = urllib.request.Request(url=url, method="GET")
+    request.add_header("Accept", "application/json")
+    with urllib.request.urlopen(request, timeout=REQUEST_TIMEOUT_S) as response:
+        body = response.read()
+    return json.loads(body)
+
+
+def record_to_can_message(record: dict) -> tuple[int, can.Message]:
+    # The records DTO pre-splits the flags, so no can_id_with_flags math is needed.
+    frame = record["frame"]
+    data = bytes.fromhex(frame["data_hex"])
+    msg = can.Message(
+        arbitration_id=int(frame["can_id"]),
+        is_extended_id=bool(frame["extended"]),
+        is_remote_frame=bool(frame["rtr"]),
+        is_error_frame=bool(frame["error"]),
+        is_fd=len(data) > 8,
+        data=data,
+    )
+    return int(record["hw_ts_us"]), msg
+
+
+def replay(
+    server: str,
+    device: str,
+    boot_ids: list[int],
+    iface: str,
+    bustype: str,
+    speed: float,
+    respect_timing: bool,
+    follow: bool,
+    fd: bool,
+    dry_run: bool,
+) -> int:
+    if dry_run:
+        LOGGER.info("Dry run: fetching from %s without opening a CAN bus", server)
+        bus = None
+    else:
+        LOGGER.info("Opening CAN bus interface=%s bustype=%s fd=%s", iface, bustype, fd)
+        bus = can.Bus(interface=bustype, channel=iface, fd=fd)
+
+    sent = 0
+    seqno_min: int | None = None
+    first_hw_ts_us: int | None = None
+    wall_start: float | None = None
+    try:
+        while True:
+            wait = FOLLOW_WAIT_TIMEOUT_S if follow else 0
+            try:
+                page = fetch_page(server, device, boot_ids, seqno_min, MAX_PAGE_LIMIT, wait)
+            except urllib.error.HTTPError as exc:
+                LOGGER.critical("Server returned HTTP %d: %s", exc.code, exc.read().decode("utf-8", "replace"))
+                return sent
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                LOGGER.critical("Failed to reach server %s: %s", server, exc)
+                return sent
+
+            records = page.get("records", [])
+            if not records:
+                if follow:
+                    LOGGER.debug("No new records; long-polling again")
+                    continue
+                LOGGER.info("No more records")
+                break
+
+            LOGGER.debug("Fetched %d records (seqno_min=%s)", len(records), seqno_min)
+            for record in records:
+                try:
+                    hw_ts_us, msg = record_to_can_message(record)
+                except Exception as exc:
+                    LOGGER.critical("Failed to build frame for seqno=%s: %s", record.get("seqno"), exc)
+                    continue
+
+                if respect_timing and not dry_run:
+                    if first_hw_ts_us is None:
+                        first_hw_ts_us = hw_ts_us
+                        wall_start = time.monotonic()
+                    else:
+                        target = wall_start + (hw_ts_us - first_hw_ts_us) / 1e6 / speed
+                        delay = target - time.monotonic()
+                        if delay > 0:
+                            time.sleep(delay)
+
+                if dry_run:
+                    LOGGER.debug("dry-run would send: %s", msg)
+                else:
+                    try:
+                        bus.send(msg)
+                    except can.CanError as exc:
+                        LOGGER.critical("bus.send failed for seqno=%s: %s", record.get("seqno"), exc)
+                        continue
+                sent += 1
+                if sent % 1000 == 0:
+                    LOGGER.debug("Sent %d frames so far", sent)
+
+            # Page by seqno: resume after the last record returned (lossless pagination).
+            seqno_min = int(records[-1]["seqno"]) + 1
+    except KeyboardInterrupt:
+        LOGGER.info("Interrupted by user, stopping")
+    finally:
+        if bus is not None:
+            LOGGER.info("Shutting down CAN bus")
+            bus.shutdown()
+
+    LOGGER.info("Replay finished: sent=%d from server=%s device=%r", sent, server, device)
+    return sent
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--server", required=True, help="Base server URL, e.g. https://cyphalcloud.zubax.com")
+    parser.add_argument("--device", required=True, help="Device name as stored on the server")
+    parser.add_argument(
+        "--boot-id",
+        type=int,
+        action="append",
+        required=True,
+        help="Boot ID to replay (repeat for multiple; timing is anchored on the first frame seen)",
+    )
+    parser.add_argument("--iface", default="vcan0", help="CAN interface channel (default: vcan0)")
+    parser.add_argument("--bustype", default="socketcan", help="python-can interface name (default: socketcan)")
+    parser.add_argument("--speed", type=float, default=1.0, help="Replay speed multiplier (default: 1.0)")
+    parser.add_argument("--no-timing", action="store_true", help="Send as fast as possible, ignore hw_ts_us")
+    parser.add_argument("--follow", action="store_true", help="Keep long-polling for new records (live tail)")
+    parser.add_argument("--no-fd", action="store_true", help="Disable CAN FD on the bus")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and log frames without opening a bus")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG/INFO/WARNING/ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    parsed = urllib.parse.urlsplit(args.server)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        LOGGER.error("--server must be a valid absolute http(s) URL, got %r", args.server)
+        return 1
+    if args.speed <= 0:
+        LOGGER.error("--speed must be positive, got %r", args.speed)
+        return 1
+    if len(args.boot_id) > 1 and not args.no_timing:
+        LOGGER.warning(
+            "Replaying %d boots with timing: hw_ts_us resets per boot, so timing may jump at boot boundaries",
+            len(args.boot_id),
+        )
+
+    sent = replay(
+        server=args.server,
+        device=args.device,
+        boot_ids=sorted(set(args.boot_id)),
+        iface=args.iface,
+        bustype=args.bustype,
+        speed=args.speed,
+        respect_timing=not args.no_timing,
+        follow=args.follow,
+        fd=not args.no_fd,
+        dry_run=args.dry_run,
+    )
+    if sent == 0:
+        LOGGER.warning("No frames replayed")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/nestor_replay.py
+++ b/tools/nestor_replay.py
@@ -1,15 +1,10 @@
 #!/usr/bin/env python3
 """
 nestor_replay: Replay CAN frames stored on a Nestor server onto a (v)CAN interface.
-
-The inverse of nestor_ingest: instead of pushing .cf3d records to the server, this
-pulls a device's recorded frames back out via the REST query API
-(GET /cf3d/api/v1/records) and transmits them with python-can, so any CAN tool
-(e.g. the DroneCAN GUI Tool) can decode/plot an archived session as if it were live.
-
-Records are paged by seqno (server caps each page; default/max page size 10000) and
-replayed with inter-frame delays derived from hw_ts_us, preserving original timing.
+Records are replayed with inter-frame delays derived from hw_ts_us, preserving original timing.
 With --follow it long-polls for new records and keeps streaming (live tail).
+
+Set up vcan0 first with `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`.
 
 Usage:
     python tools/nestor_replay.py --server https://cyphalcloud.zubax.com \
@@ -18,8 +13,6 @@ Usage:
         --device my-drone --boot-id 1 --iface vcan0 --speed 2.0
     python tools/nestor_replay.py --server http://localhost:8000 \
         --device my-drone --boot-id 1 --iface vcan0 --follow
-
-Set up vcan0 first with `sudo modprobe vcan && sudo ip link add dev vcan0 type vcan && sudo ip link set up vcan0`.
 """
 
 from __future__ import annotations

--- a/tools/replay_cf3d.py
+++ b/tools/replay_cf3d.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+replay_cf3d: Replay CAN frames from a .cf3d file onto a (v)CAN interface.
+
+Reads RECORD_BYTES-sized records, unboxes them with the FEC envelope, decodes
+the same user-data layout produced by tools/export_cf3d.py, and transmits the
+frames via python-can. Inter-frame delays are derived from hw_ts_us so the
+replay preserves the original timing.
+
+Usage:
+    python tools/replay_cf3d.py --iface vcan0 dump.cf3d
+    python tools/replay_cf3d.py --iface vcan0 --speed 2.0 dump.cf3d
+    python tools/replay_cf3d.py --iface vcan0 --no-timing dump.cf3d
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import struct
+import sys
+import time
+from pathlib import Path
+
+import can
+
+from nestor.fec_envelope import unbox, UnboxError, RECORD_BYTES
+from nestor.model import CAN_EFF_FLAG, CAN_RTR_FLAG, CAN_ERR_FLAG, CAN_ID_EXT_MASK
+
+LOGGER = logging.getLogger("replay_cf3d")
+
+
+def unpack_cf3d_record(user: bytes) -> tuple[int, int, int, int, bytes]:
+    version = user[0]
+    if version != 0:
+        raise ValueError(f"unsupported cf3d record version: {version}")
+    boot_id, seqno, hw_ts_us = struct.unpack_from("<QQQ", user, 8)
+    (can_id_with_flags,) = struct.unpack_from("<I", user, 36)
+    dlc = user[40]
+    if dlc > 64:
+        raise ValueError(f"invalid CAN payload length: {dlc}")
+    data = bytes(user[41 : 41 + dlc])
+    return boot_id, seqno, hw_ts_us, can_id_with_flags, data
+
+
+def to_can_message(can_id_with_flags: int, data: bytes) -> can.Message:
+    return can.Message(
+        arbitration_id=can_id_with_flags & CAN_ID_EXT_MASK,
+        is_extended_id=bool(can_id_with_flags & CAN_EFF_FLAG),
+        is_remote_frame=bool(can_id_with_flags & CAN_RTR_FLAG),
+        is_error_frame=bool(can_id_with_flags & CAN_ERR_FLAG),
+        is_fd=len(data) > 8,
+        data=data,
+    )
+
+
+def replay(
+    path: Path,
+    iface: str,
+    bustype: str,
+    speed: float,
+    respect_timing: bool,
+    fd: bool,
+    dry_run: bool,
+) -> int:
+    if dry_run:
+        LOGGER.info("Dry run: parsing %s without opening a CAN bus", path)
+        bus = None
+    else:
+        LOGGER.info("Opening CAN bus interface=%s bustype=%s fd=%s", iface, bustype, fd)
+        bus = can.Bus(interface=bustype, channel=iface, fd=fd)
+    sent = 0
+    skipped = 0
+    first_hw_ts_us: int | None = None
+    wall_start: float | None = None
+    try:
+        with path.open("rb") as fh:
+            LOGGER.info("Reading cf3d records from %s", path)
+            while True:
+                record = fh.read(RECORD_BYTES)
+                if not record:
+                    break
+                if len(record) != RECORD_BYTES:
+                    LOGGER.warning("Trailing %d bytes ignored (not a full record)", len(record))
+                    break
+
+                result = unbox(record)
+                if isinstance(result, UnboxError):
+                    LOGGER.warning("Skipping unboxable record #%d: %s", sent + skipped, result)
+                    skipped += 1
+                    continue
+                user = result
+
+                try:
+                    boot_id, seqno, hw_ts_us, can_id_with_flags, data = unpack_cf3d_record(user)
+                except Exception as exc:
+                    LOGGER.critical("Failed to unpack record #%d: %s", sent + skipped, exc)
+                    skipped += 1
+                    continue
+
+                LOGGER.debug(
+                    "record boot_id=%d seqno=%d hw_ts_us=%d can_id=0x%08x dlc=%d",
+                    boot_id,
+                    seqno,
+                    hw_ts_us,
+                    can_id_with_flags,
+                    len(data),
+                )
+
+                if respect_timing and not dry_run:
+                    if first_hw_ts_us is None:
+                        first_hw_ts_us = hw_ts_us
+                        wall_start = time.monotonic()
+                    else:
+                        target = wall_start + (hw_ts_us - first_hw_ts_us) / 1e6 / speed
+                        delay = target - time.monotonic()
+                        if delay > 0:
+                            time.sleep(delay)
+
+                msg = to_can_message(can_id_with_flags, data)
+                if dry_run:
+                    LOGGER.debug("dry-run would send: %s", msg)
+                else:
+                    try:
+                        bus.send(msg)
+                    except can.CanError as exc:
+                        LOGGER.critical("bus.send failed for seqno=%d: %s", seqno, exc)
+                        skipped += 1
+                        continue
+                sent += 1
+                if sent % 1000 == 0:
+                    LOGGER.debug("Sent %d frames so far", sent)
+    finally:
+        if bus is not None:
+            LOGGER.info("Shutting down CAN bus")
+            bus.shutdown()
+
+    LOGGER.info("Replay finished: sent=%d skipped=%d from %s", sent, skipped, path)
+    return sent
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("file", type=Path, help="Path to .cf3d file to replay")
+    parser.add_argument("--iface", default="vcan0", help="CAN interface channel (default: vcan0)")
+    parser.add_argument("--bustype", default="socketcan", help="python-can interface name (default: socketcan)")
+    parser.add_argument("--speed", type=float, default=1.0, help="Replay speed multiplier (default: 1.0)")
+    parser.add_argument("--no-timing", action="store_true", help="Send as fast as possible, ignore hw_ts_us")
+    parser.add_argument("--no-fd", action="store_true", help="Disable CAN FD on the bus")
+    parser.add_argument("--dry-run", action="store_true", help="Parse file and log frames without opening a bus")
+    parser.add_argument("--log-level", default="INFO", help="Logging level (DEBUG/INFO/WARNING/ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+
+    if not args.file.exists():
+        LOGGER.error("Input file not found: %s", args.file)
+        return 1
+    if args.speed <= 0:
+        LOGGER.error("--speed must be positive, got %r", args.speed)
+        return 1
+
+    sent = replay(
+        path=args.file,
+        iface=args.iface,
+        bustype=args.bustype,
+        speed=args.speed,
+        respect_timing=not args.no_timing,
+        fd=not args.no_fd,
+        dry_run=args.dry_run,
+    )
+    if sent == 0:
+        LOGGER.warning("No frames replayed")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/replay_cf3d.py
+++ b/tools/replay_cf3d.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python3
 """
 replay_cf3d: Replay CAN frames from a .cf3d file onto a (v)CAN interface.
-
-Reads RECORD_BYTES-sized records, unboxes them with the FEC envelope, decodes
-the same user-data layout produced by tools/export_cf3d.py, and transmits the
-frames via python-can. Inter-frame delays are derived from hw_ts_us so the
-replay preserves the original timing.
+Inter-frame delays are derived from hw_ts_us so the replay preserves the original timing.
 
 Usage:
     python tools/replay_cf3d.py --iface vcan0 dump.cf3d


### PR DESCRIPTION
## Adding the following scripts:
- **`capture_cf3d.py`** — record live CAN frames from a (v)CAN interface into a `.cf3d` file. 
- **`nestor_replay.py`** — pull a device's recorded frames from a nestor server (`GET /cf3d/api/v1/records`) and replay them onto a (v)CAN interface.
- **`nestor_ingest.py`** — lower the upload chunk size to 256 KB so uploads clear typical reverse-proxy request-size limits (HTTP 413).

## Adding 
- Document the tools in `tools/README.md`.
- Link the demo video in `README.md`: https://youtu.be/YgZulY8uraQ